### PR TITLE
Add default logging config

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -122,6 +122,54 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+
+# Logging
+# https://docs.djangoproject.com/en/stable/topics/logging/
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        # Send logs with at least INFO level to the console.
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "formatters": {
+        "verbose": {
+            "format": "[%(asctime)s][%(process)d][%(levelname)s][%(name)s] %(message)s"
+        }
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "WARNING",
+    },
+    "loggers": {
+        "app": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "config": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "django.security": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
+}
+
+
 # TNA Configuration
 
 ENVIRONMENT: str = os.environ.get("ENVIRONMENT", "production")


### PR DESCRIPTION
I noticed that there is no default logging configuration.

This means that you only see Gunicorn logs once deployed, but the application logs are not coming through.

You can's see tracebacks in logs without having a working handler for `django.request` which seems to only work in the debug mode with the default logging configuration.

Although it may be desirable to keep logs clean, and use something like Sentry for the tracebacks.